### PR TITLE
use `.tree` not `tree` in args to `map_tree`

### DIFF
--- a/man/map_tree.Rd
+++ b/man/map_tree.Rd
@@ -10,12 +10,12 @@ map_tree(.x, .f, ..., .field = NULL)
 \item{.x}{The `Tree`}
 
 \item{.f}{The function to be applied to the `Node`s in the
-`Tree`. If .f has an argument called `tree` then `map_tree` will pass the
+`Tree`. If .f has an argument called `.tree` then `map_tree` will pass the
 `Tree` `.x` in as that argument automatically.}
 
 \item{...}{Further arguments to be passed into the function
-`.f`. Except: if the function `.f` takes an argument `tree`, then `.x` is
-passed in as the `tree` argument automatically.}
+`.f`. Except: if the function `.f` takes an argument `.tree`, then `.x` is
+passed in as the `.tree` argument automatically.}
 
 \item{.field}{If a string is provided, the values of `.f` will
 be appended to the respective `Node`s in the `Tree`; `.field` gives the

--- a/tests/testthat/test_map.R
+++ b/tests/testthat/test_map.R
@@ -39,9 +39,9 @@ test_that("The `Node`s in a `Tree` can be mapped over", {
 })
 
 test_that(".. the `map` function can use pre-existing values in the `Tree`", {
-  count_siblings <- function(node, tree) {
+  count_siblings <- function(node, .tree) {
     n_siblings <- if (has_parent(node)) {
-      parent <- get_parent(tree, node)
+      parent <- get_parent(.tree, node)
       length(parent$children)
     } else {
       1
@@ -62,9 +62,9 @@ test_that(".. the `map` function can use pre-existing values in the `Tree`", {
 test_that(".. `map` results for `Node`s can be used by their children", {
   # update the field "name_sum" as you traverse down the `Tree`
 
-  name_sum <- function(node, tree) {
+  name_sum <- function(node, .tree) {
     if (has_parent(node)) {
-      nchar(node$name) + get_parent(tree, node)$name_sum
+      nchar(node$name) + get_parent(.tree, node)$name_sum
     } else {
       nchar(node$name)
     }


### PR DESCRIPTION
Also changed internally-used `node` argument to `.node` and replaced use of
`within(list(...), rm(tree))`.

Although I couldn't make a reprex, in it's earlier form I kept receiving
`object of type 'closure' is not subsettable` when using the names `node` and
`tree` as variables (given that they are also exported functions).